### PR TITLE
Test node rafal

### DIFF
--- a/casper/casper-common/Cargo.toml
+++ b/casper/casper-common/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 
 [dependencies]
 contract-util = { path = "../contract-util", default-features = false }
-casper-types = { git = "https://github.com/rafal-ch/casper-node", branch = "contract_error_dump_on_1_5" }
+casper-types = { git = "https://github.com/Jiuhong-casperlabs/casper-node.git", branch = "contract_error_dump_on_1_5" }

--- a/casper/casper-common/Cargo.toml
+++ b/casper/casper-common/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 
 [dependencies]
 contract-util = { path = "../contract-util", default-features = false }
-casper-types   = { git = "https://github.com/Jiuhong-casperlabs/casper-node.git", rev = "06ad2300310587186f16bc4acaef94efcc4fc8f7" }
+casper-types = { git = "https://github.com/rafal-ch/casper-node", branch = "contract_error_dump_on_1_5" }

--- a/casper/connectors-common/Cargo.toml
+++ b/casper/connectors-common/Cargo.toml
@@ -17,5 +17,5 @@ anyhow = "1.0.0"
 thiserror = "1.0.0"
 tonic = "0.8"
 
-casper-types = { git = "https://github.com/rafal-ch/casper-node", branch = "contract_error_dump_on_1_5", optional = true }
+casper-types = { git = "https://github.com/Jiuhong-casperlabs/casper-node.git", branch = "contract_error_dump_on_1_5", optional = true }
 primitive-types = { version = "0.11.1", optional = true }

--- a/casper/connectors-common/Cargo.toml
+++ b/casper/connectors-common/Cargo.toml
@@ -17,5 +17,5 @@ anyhow = "1.0.0"
 thiserror = "1.0.0"
 tonic = "0.8"
 
-casper-types = { git = "https://github.com/Jiuhong-casperlabs/casper-node.git", rev = "06ad2300310587186f16bc4acaef94efcc4fc8f7", optional = true }
+casper-types = { git = "https://github.com/rafal-ch/casper-node", branch = "contract_error_dump_on_1_5", optional = true }
 primitive-types = { version = "0.11.1", optional = true }

--- a/casper/contract-bridge-tests/Cargo.toml
+++ b/casper/contract-bridge-tests/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 
 [dependencies]
 base64 = "0.13.0"
-casper-contract = { git = "https://github.com/rafal-ch/casper-node", branch = "contract_error_dump_on_1_5", default-features = false }
-casper-engine-test-support = { git = "https://github.com/rafal-ch/casper-node", branch = "contract_error_dump_on_1_5", features = [
+casper-contract = { git = "https://github.com/Jiuhong-casperlabs/casper-node.git", branch = "contract_error_dump_on_1_5", default-features = false }
+casper-engine-test-support = { git = "https://github.com/Jiuhong-casperlabs/casper-node.git", branch = "contract_error_dump_on_1_5", features = [
   "test-support",
 ] }
-casper-execution-engine = { git = "https://github.com/rafal-ch/casper-node", branch = "contract_error_dump_on_1_5" }
-casper-types = { git = "https://github.com/rafal-ch/casper-node", branch = "contract_error_dump_on_1_5" }
+casper-execution-engine = { git = "https://github.com/Jiuhong-casperlabs/casper-node.git", branch = "contract_error_dump_on_1_5" }
+casper-types = { git = "https://github.com/Jiuhong-casperlabs/casper-node.git", rev = "06ad2300310587186f16bc4acaef94efcc4fc8f7" }
 k256 = { version = "0.10.4", features = ["pem"] }
 base16 = { version = "0.2.1", default-features = false }
 

--- a/casper/contract-bridge-tests/Cargo.toml
+++ b/casper/contract-bridge-tests/Cargo.toml
@@ -5,13 +5,15 @@ edition = "2021"
 
 [dependencies]
 base64 = "0.13.0"
-casper-contract = { git = "https://github.com/Jiuhong-casperlabs/casper-node.git", rev = "06ad2300310587186f16bc4acaef94efcc4fc8f7", default-features = false }
-casper-engine-test-support = { git = "https://github.com/Jiuhong-casperlabs/casper-node.git", rev = "06ad2300310587186f16bc4acaef94efcc4fc8f7", features = ["test-support"] }
-casper-execution-engine = { git = "https://github.com/Jiuhong-casperlabs/casper-node.git", rev = "06ad2300310587186f16bc4acaef94efcc4fc8f7" }
-casper-types   = { git = "https://github.com/Jiuhong-casperlabs/casper-node.git", rev = "06ad2300310587186f16bc4acaef94efcc4fc8f7" }
+casper-contract = { git = "https://github.com/rafal-ch/casper-node", branch = "contract_error_dump_on_1_5", default-features = false }
+casper-engine-test-support = { git = "https://github.com/rafal-ch/casper-node", branch = "contract_error_dump_on_1_5", features = [
+  "test-support",
+] }
+casper-execution-engine = { git = "https://github.com/rafal-ch/casper-node", branch = "contract_error_dump_on_1_5" }
+casper-types = { git = "https://github.com/rafal-ch/casper-node", branch = "contract_error_dump_on_1_5" }
 k256 = { version = "0.10.4", features = ["pem"] }
 base16 = { version = "0.2.1", default-features = false }
 
-casper-common  = { path = "../casper-common" }
+casper-common = { path = "../casper-common" }
 contract-bridge = { path = "../contract-bridge" }
 contract-util = { path = "../contract-util" }

--- a/casper/contract-bridge/Cargo.toml
+++ b/casper/contract-bridge/Cargo.toml
@@ -10,10 +10,10 @@ onchain = ["contract-util/onchain"]
 test-support = ["casper-contract/test-support"]
 
 [dependencies]
-casper-contract = { git = "https://github.com/rafal-ch/casper-node", branch = "contract_error_dump_on_1_5", features = [
+casper-contract = { git = "https://github.com/Jiuhong-casperlabs/casper-node.git", branch = "contract_error_dump_on_1_5", features = [
   "test-support",
 ] }
-casper-types = { git = "https://github.com/rafal-ch/casper-node", branch = "contract_error_dump_on_1_5" }
+casper-types = { git = "https://github.com/Jiuhong-casperlabs/casper-node.git", branch = "contract_error_dump_on_1_5" }
 contract-util = { path = "../contract-util", default-features = false }
 casper-common = { path = "../casper-common" }
 num_enum = { version = "0.5.7", default-features = false }

--- a/casper/contract-bridge/Cargo.toml
+++ b/casper/contract-bridge/Cargo.toml
@@ -7,11 +7,13 @@ edition = "2018"
 default = ["std", "test-support"]
 std = ["thiserror", "contract-util/std"]
 onchain = ["contract-util/onchain"]
-test-support=["casper-contract/test-support"]
+test-support = ["casper-contract/test-support"]
 
 [dependencies]
-casper-contract = { git = "https://github.com/Jiuhong-casperlabs/casper-node.git", rev = "06ad2300310587186f16bc4acaef94efcc4fc8f7", default-features = false }
-casper-types   = { git = "https://github.com/Jiuhong-casperlabs/casper-node.git", rev = "06ad2300310587186f16bc4acaef94efcc4fc8f7" }
+casper-contract = { git = "https://github.com/rafal-ch/casper-node", branch = "contract_error_dump_on_1_5", features = [
+  "test-support",
+] }
+casper-types = { git = "https://github.com/rafal-ch/casper-node", branch = "contract_error_dump_on_1_5" }
 contract-util = { path = "../contract-util", default-features = false }
 casper-common = { path = "../casper-common" }
 num_enum = { version = "0.5.7", default-features = false }

--- a/casper/contract-util/Cargo.toml
+++ b/casper/contract-util/Cargo.toml
@@ -11,13 +11,17 @@ onchain = ["casper-contract/no-std-helpers"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-casper-contract = { git = "https://github.com/Jiuhong-casperlabs/casper-node.git", rev = "06ad2300310587186f16bc4acaef94efcc4fc8f7", default-features = false, features = ["test-support"] }
-casper-types    = { git = "https://github.com/Jiuhong-casperlabs/casper-node.git", rev = "06ad2300310587186f16bc4acaef94efcc4fc8f7" }
+casper-contract = { git = "https://github.com/rafal-ch/casper-node", branch = "contract_error_dump_on_1_5", features = [
+  "test-support",
+] }
+casper-types = { git = "https://github.com/rafal-ch/casper-node", branch = "contract_error_dump_on_1_5" }
 
 num_enum = { version = "0.5.7", default-features = false }
 
 once_cell = { version = "1.12.0", default-features = false }
 thiserror = { version = "1.0.31", optional = true }
+
+# this conflicts with casper node 3.0.0
 k256 = { version = "0.10.4", default-features = false, features = ["pem"] }
 base16 = { version = "0.2.1", default-features = false }
 

--- a/casper/contract-util/Cargo.toml
+++ b/casper/contract-util/Cargo.toml
@@ -21,7 +21,7 @@ num_enum = { version = "0.5.7", default-features = false }
 once_cell = { version = "1.12.0", default-features = false }
 thiserror = { version = "1.0.31", optional = true }
 
-# this conflicts with casper node 3.0.0
+# casper types is max 0.7.2
 k256 = { version = "0.10.4", default-features = false, features = ["pem"] }
 base16 = { version = "0.2.1", default-features = false }
 

--- a/casper/contract-util/Cargo.toml
+++ b/casper/contract-util/Cargo.toml
@@ -11,10 +11,10 @@ onchain = ["casper-contract/no-std-helpers"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-casper-contract = { git = "https://github.com/rafal-ch/casper-node", branch = "contract_error_dump_on_1_5", features = [
+casper-contract = { git = "https://github.com/Jiuhong-casperlabs/casper-node.git", branch = "contract_error_dump_on_1_5", features = [
   "test-support",
 ] }
-casper-types = { git = "https://github.com/rafal-ch/casper-node", branch = "contract_error_dump_on_1_5" }
+casper-types = { git = "https://github.com/Jiuhong-casperlabs/casper-node.git", branch = "contract_error_dump_on_1_5" }
 
 num_enum = { version = "0.5.7", default-features = false }
 


### PR DESCRIPTION
@Jiuhong-casperlabs If you apply Rafal's patch to https://github.com/Jiuhong-casperlabs/casper-node.git and create a branch of it like contract_error_dump_on_1_5, then these toml files should compile 